### PR TITLE
Fix multiplayer server browser

### DIFF
--- a/code/q3_ui/ui_menu.c
+++ b/code/q3_ui/ui_menu.c
@@ -392,12 +392,12 @@ void UI_MainMenu( void ) {
 
 	y += MAIN_MENU_VERTICAL_SPACING;
 	s_main.multiplayer.generic.type			= MTYPE_PTEXT;
-	s_main.multiplayer.generic.flags		= QMF_LEFT_JUSTIFY|QMF_PULSEIFFOCUS/*|QMF_GRAYED*/;
+	s_main.multiplayer.generic.flags		= QMF_LEFT_JUSTIFY|QMF_PULSEIFFOCUS;
 	s_main.multiplayer.generic.x			= x;
 	s_main.multiplayer.generic.y			= y;
 	s_main.multiplayer.generic.id			= ID_MULTIPLAYER;
 	s_main.multiplayer.generic.callback		= Main_MenuEvent;
-	s_main.multiplayer.string				= "MULTIPLAYER  (BROWSER NOT WORKING)";
+	s_main.multiplayer.string				= "MULTIPLAYER";
 	s_main.multiplayer.color				= color_red;
 	s_main.multiplayer.style				= style;
 

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -35,13 +35,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define HOMEPATH_NAME_MACOSX		HOMEPATH_NAME_WIN
 //  #define STEAMPATH_NAME			"MFArena"
 //  #define STEAMPATH_APPID         ""
-#define GAMENAME_FOR_MASTER			"Quake3Arena"	// must NOT contain whitespace
+#define GAMENAME_FOR_MASTER			"MFArena"	// must NOT contain whitespace
 #define CINEMATICS_LOGO				"mmplogo.roq"
 #define CINEMATICS_INTRO			"intro.roq"
 #define LEGACY_PROTOCOL								// You probably don't need this for your standalone game
 
 // Heartbeat for dpmaster protocol. You shouldn't change this unless you know what you're doing
-#define HEARTBEAT_FOR_MASTER		"QuakeArena-1"
+#define HEARTBEAT_FOR_MASTER		"DarkPlaces"
 #define LEGACY_PROTOCOL // this line must exist to show all servers
 
 // When com_gamename is LEGACY_MASTER_GAMENAME, use quake3 master protocol.


### PR DESCRIPTION
Use DarkPlaces master server protocol so that MFArena servers are listed on dpmaster master servers and fetched correctly.

The reason using q3master protocol did not work before was the protocol number. Setting PROTOCOL_LEGACY_VERSION to 68 would cause servers to be listed and browser to work. Though then MFArena is not a separate game from Quake 3 so it's best to use dpmaster protocol.

To view Quake 3 servers in the browser (for UI testing) use:

    mfarena.x86 +set com_gamename Quake3Arena +set com_legacyprotocol 68

I am currently running a MFArena server (git master with this patch, svinfo version 18.0) to demonstration that the server browser works. Apply this [patch](https://github.com/zturtleman/ioq3/commit/05a8740198c096c5c127307702e77bff111cc348.patch) to git master and build the client and ui.qvm (so UI's SVINFO_VERSION_YR and SVINFO_VERSION_SV match server from git master). Then run client using UI from git and it should show my server in the multiplayer server browser. Running a server with `mfarena.x86 +set dedicated 2 +map mfdm01` should be listed in the server browser if you have port forwarding setup for UDP port 27960.